### PR TITLE
Fix resolving of CURIES.

### DIFF
--- a/simplehal/__init__.py
+++ b/simplehal/__init__.py
@@ -42,7 +42,7 @@ class HalDocument(object):
         """
         curies = {}
         try:
-            curie_links = self.structure['_links']['curie']
+            curie_links = self.structure['_links']['curies']
             if not hasattr(curie_links, 'append'):
                 curie_links = [curie_links]
             for link in curie_links:

--- a/test/test_consume.py
+++ b/test/test_consume.py
@@ -37,7 +37,7 @@ def test_handle_curie():
     data = {
             '_links': {
                 'self': {'href': '/hi'},
-                'curie': {
+                'curies': {
                     'href': 'http://example.com/barnacle/{rel}',
                     'name': 'barnacle',
                     'templated': True


### PR DESCRIPTION
The specification https://tools.ietf.org/html/draft-kelly-json-hal-08 says `curies` not `curie`.